### PR TITLE
Update postgresql containers to be able to build and test world

### DIFF
--- a/postgres/fedora/26/Dockerfile
+++ b/postgres/fedora/26/Dockerfile
@@ -20,4 +20,6 @@ RUN sudo dnf update -y \
         readline-devel \
         tcl-devel \
         uuid-devel \
-        zlib-devel
+        zlib-devel \
+        libxml2 \
+        libxslt

--- a/postgres/ubuntu/14.04/Dockerfile
+++ b/postgres/ubuntu/14.04/Dockerfile
@@ -27,4 +27,6 @@ RUN sudo apt-get update \
         tcl \
         tcl-dev \
         zlib1g-dev \
+        libxml2-utils \
+        xsltproc \
  && sudo apt-get clean

--- a/postgres/ubuntu/16.04/Dockerfile
+++ b/postgres/ubuntu/16.04/Dockerfile
@@ -27,4 +27,6 @@ RUN sudo apt-get update \
         tcl \
         tcl-dev \
         zlib1g-dev \
+        libxml2-utils \
+        xsltproc \
  && sudo apt-get clean

--- a/postgres/ubuntu/18.04/Dockerfile
+++ b/postgres/ubuntu/18.04/Dockerfile
@@ -27,4 +27,6 @@ RUN sudo apt-get update \
         tcl \
         tcl-dev \
         zlib1g-dev \
+        libxml2-utils \
+        xsltproc \
  && sudo apt-get clean


### PR DESCRIPTION
support the following build targets for postgres:
make world
make check-world