### PR TITLE
Added commonly used packages in crave container

### DIFF
--- a/crave/pipeline/Dockerfile
+++ b/crave/pipeline/Dockerfile
@@ -10,6 +10,8 @@ RUN export DEBIAN_FRONTEND=noninteractive \
     rsync \
     pigz \
     make \
-    jq
+    jq \
+    curl \
+    wget
 
 COPY bin/crave /usr/local/bin

--- a/crave/pipeline/Dockerfile
+++ b/crave/pipeline/Dockerfile
@@ -9,6 +9,7 @@ RUN export DEBIAN_FRONTEND=noninteractive \
     git \
     rsync \
     pigz \
-    make
+    make \
+    jq
 
 COPY bin/crave /usr/local/bin

--- a/crave/pipeline/Dockerfile
+++ b/crave/pipeline/Dockerfile
@@ -2,8 +2,9 @@
 FROM ubuntu:18.04
 MAINTAINER Crave.io Inc. "contact@crave.io"
 
-RUN export DEBIAN_FRONTEND=noninteractive \
- && apt-get update \
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update \
  && apt-get -y dist-upgrade \
  && apt-get install -y \
     git \
@@ -12,6 +13,22 @@ RUN export DEBIAN_FRONTEND=noninteractive \
     make \
     jq \
     curl \
-    wget
+    wget \
+    gnupg2 \
+    software-properties-common
+
+# Install awscli and gcloud
+RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk main" \
+    | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list \
+    && curl https://packages.cloud.google.com/apt/doc/apt-key.gpg \
+    | apt-key --keyring /usr/share/keyrings/cloud.google.gpg add - \
+    && apt-get -y update \
+    && apt-get -y install google-cloud-sdk awscli
+
+# install docker cli
+RUN curl -fsSL https://download.docker.com/linux/static/stable/x86_64/docker-19.03.7.tgz -o /tmp/docker-cli.tgz \
+    && tar -zxf /tmp/docker-cli.tgz --strip 1 -C /usr/local/bin/ docker/docker \
+    && rm -rf /tmp/*.tgz \
+    && chmod +x /usr/local/bin/docker
 
 COPY bin/crave /usr/local/bin

--- a/crave/pipeline/Dockerfile
+++ b/crave/pipeline/Dockerfile
@@ -8,6 +8,7 @@ RUN export DEBIAN_FRONTEND=noninteractive \
  && apt-get install -y \
     git \
     rsync \
-    pigz
+    pigz \
+    make
 
 COPY bin/crave /usr/local/bin


### PR DESCRIPTION
Below mentioned packages are needed inside crave container.

Customers might use these packages in build workflow. Crave build system is an example.

make
jq
wget
curl
gcloud
awscli
docker