### PR TITLE
ubuntu 20.04: remove offending optin from sshd_config

### DIFF
--- a/baseimages/phase1/ubuntu/20.04/sshd_config
+++ b/baseimages/phase1/ubuntu/20.04/sshd_config
@@ -44,7 +44,6 @@ PubkeyAuthentication yes
 # Expect .ssh/authorized_keys2 to be disregarded by default in future.
 #AuthorizedKeysFile	.ssh/authorized_keys .ssh/authorized_keys2
 PubkeyAcceptedKeyTypes=+ssh-rsa
-PubkeyAcceptedAlgorithms=+ssh-rsa
 
 #AuthorizedPrincipalsFile none
 


### PR DESCRIPTION
removed option PubkeyAcceptedAlgorithms
This was not recognized by sshd and it was terminating.