### PR TITLE
Delete shallow.lock files before syncing

### DIFF
--- a/aosp/resync.sh
+++ b/aosp/resync.sh
@@ -2,6 +2,7 @@
 
 main() {
     # Run repo sync command and capture the output
+    find .repo -name '*.lock' -delete
     repo sync -c -j$(nproc --all) --force-sync --no-clone-bundle --no-tags --prune 2>&1 | tee /tmp/output.txt
 
     # Check if there are any failing repositories


### PR DESCRIPTION
Sometimes due to complications in the previous repo sync, shallow.lock files get left out, causing this error:

fatal: Unable to create '/tmp/src/android/.repo/projects/hardware/interfaces.git/shallow.lock': File exists.

Another git process seems to be running in this repository, e.g., an editor opened by 'git commit'. Please make sure all processes are terminated, then try again. If it still fails, a git process may have crashed in this repository earlier; remove the file manually to continue.

So, let's remove it before the repo sync and allow it to be regenerated.