### PR TITLE
Delete .lock files during second stage repo sync

### DIFF
--- a/aosp/resync.sh
+++ b/aosp/resync.sh
@@ -24,6 +24,7 @@ main() {
 
         # Re-sync all repositories after deletion
         echo "Re-syncing all repositories..."
+        find .repo -name '*.lock' -delete
         repo sync -c -j$(nproc --all) --force-sync --no-clone-bundle --no-tags --prune
     else
         echo "All repositories synchronized successfully."


### PR DESCRIPTION
Deleting it during the first repo sync is only beneficial if the conflicts occurred during the previous repo syncs, but it may also occur after the first repo sync in this script, especially with a newly re-initialized repo. So we should also delete it in second repo sync to ensure that there will be no failing repo and existing shallow.lock files that may cause error before the final repo sync.