### PR TITLE
Revise repo sync

### DIFF
--- a/aosp/common/resync.sh
+++ b/aosp/common/resync.sh
@@ -3,7 +3,7 @@
 main() {
     # Run repo sync command and capture the output
     find .repo -name '*.lock' -delete
-    repo sync -c -j$(nproc --all) --force-sync --no-clone-bundle --no-tags --prune 2>&1 | tee /tmp/output.txt
+    repo sync -c --no-clone-bundle --no-tags --optimized-fetch --prune --force-sync 2>&1 | tee /tmp/output.txt
 
     # Check if there are any failing repositories
     if grep -q "Failing repos:" /tmp/output.txt ; then
@@ -25,7 +25,7 @@ main() {
         # Re-sync all repositories after deletion
         echo "Re-syncing all repositories..."
         find .repo -name '*.lock' -delete
-        repo sync -c -j$(nproc --all) --force-sync --no-clone-bundle --no-tags --prune
+        repo sync -c --no-clone-bundle --no-tags --optimized-fetch --prune --force-sync
     else
         echo "All repositories synchronized successfully."
     fi


### PR DESCRIPTION
* Add --optimized-fetch

* Don't specify jobs value
(This might be the reason why some builds are getting stuck in repo sync. If we don't specify a value for jobs, it will use the default value in the AOSP manifest, which is "-j4" set by Google itself, so let's keep it that way)

https://android.googlesource.com/platform/manifest/+/refs/heads/main/default.xml#9