### PR TITLE
Github releases: Upload most files seperately

### DIFF
--- a/aosp/common/upload.sh
+++ b/aosp/common/upload.sh
@@ -58,5 +58,6 @@ if [ "${DCDEVSPACE}" == "1" ]; then
     crave push token.txt -d $(crave ssh -- pwd | grep -v Select | sed -s 's/\r//g')/
     crave ssh -- "export GH_UPLOAD_LIMIT="$GH_UPLOAD_LIMIT"; bash /opt/crave/github-actions/upload.sh "$RELEASETAG" "$DEVICE" "$REPONAME" "$RELEASETITLE""
 else
-    gh release create $RELEASETAG $ZIP_FILES $IMG_FILES $EXTRAFILES --repo $REPONAME --title $RELEASETITLE --generate-notes
+    gh release create $RELEASETAG $EXTRAFILES --repo $REPONAME --title $RELEASETITLE --generate-notes
+    gh release upload $RELEASETAG --repo $REPONAME $ZIP_FILES $IMG_FILES
 fi


### PR DESCRIPTION
Using gh release upload instead of relying on gh release create

Might fix HTTP 500 errors