### PR TITLE
aosp: ubuntu: Add python3-mako

### DIFF
--- a/aosp/ubuntu/Dockerfile
+++ b/aosp/ubuntu/Dockerfile
@@ -76,6 +76,7 @@ RUN set -x \
     pngcrush \
     python2 \
     python3 \
+    python3-mako \
     schedtool \
     sed \
     squashfs-tools \


### PR DESCRIPTION
Try to fix "meson.build:944:2: ERROR: Problem encountered: Python (3.x) mako module >= 0.8.0 required to build mesa."