### PR TITLE
fix: make resync delete repos when they have uncommitted changes

### DIFF
--- a/aosp/common/resync.sh
+++ b/aosp/common/resync.sh
@@ -6,11 +6,17 @@ main() {
     find .repo -name '*.lock' -delete
     repo sync -c -j$(nproc --all) --force-sync --no-clone-bundle --no-tags --prune 2>&1 | tee /tmp/output.txt
 
+    if ! grep -qe "Failing repos:\|uncommitted changes are present" /tmp/output.txt ; then
+         echo "All repositories synchronized successfully."
+         exit 0
+    else
+        rm -f deleted_repositories.txt
+    fi
+
     # Check if there are any failing repositories
     if grep -q "Failing repos:" /tmp/output.txt ; then
         echo "Deleting failing repositories..."
         # Extract failing repositories from the error message and echo the deletion path
-        rm -f deleted_repositories.txt
         while IFS= read -r line; do
             # Extract repository name and path from the error message
             repo_info=$(echo "$line" | awk -F': ' '{print $NF}')
@@ -21,14 +27,29 @@ main() {
             # Delete the repository
             rm -rf "$repo_path/$repo_name"
         done <<< "$(cat /tmp/output.txt | awk '/Failing repos:/ {flag=1; next} /Try/ {flag=0} flag')"
-
-        # Re-sync all repositories after deletion
-        echo "Re-syncing all repositories..."
-        find .repo -name '*.lock' -delete
-        repo sync -c -j$(nproc --all) --force-sync --no-clone-bundle --no-tags --prune
-    else
-        echo "All repositories synchronized successfully."
     fi
+
+    # Check if there are any failing repositories due to uncommitted changes
+    if grep -q "uncommitted changes are present" /tmp/output.txt ; then
+        echo "Deleting repositories with uncommitted changes..."
+
+        # Extract failing repositories from the error message and echo the deletion path
+        while IFS= read -r line; do
+            # Extract repository name and path from the error message
+            repo_info=$(echo "$line" | awk -F': ' '{print $2}')
+            repo_path=$(dirname "$repo_info")
+            repo_name=$(basename "$repo_info")
+            # Save the deletion path to a text file
+            echo "Deleted repository: $repo_info" | tee -a deleted_repositories.txt
+            # Delete the repository
+            rm -rf "$repo_path/$repo_name"
+        done <<< "$(cat /tmp/output.txt | grep 'uncommitted changes are present')"
+    fi
+
+    # Re-sync all repositories after deletion
+    echo "Re-syncing all repositories..."
+    find .repo -name '*.lock' -delete
+    repo sync -c -j$(nproc --all) --force-sync --no-clone-bundle --no-tags --prune
 }
 
 main $*


### PR DESCRIPTION
Resync does not currently remove a repository if it has uncommitted changes. This aims to fix that.