### PR TITLE
aosp: ubuntu: Add git-lfs

### DIFF
--- a/aosp/ubuntu/Dockerfile
+++ b/aosp/ubuntu/Dockerfile
@@ -56,6 +56,7 @@ RUN set -x \
     gcc-arm-linux-gnueabi \
     gcc-arm-linux-gnueabihf \
     git \
+    git-lfs \
     gperf \
     jq \
     liblz4-tool \


### PR DESCRIPTION
Is necessary git-lfs to fix mismatch hashs that occurs because corrupted files in vendor tree that have big firmwares.
big firmwares images depends to be transported using a LFS because of git limits 