### PR TITLE
backblaze_keygen: sign APEX with SHA256_RSA4096 key.

### DIFF
--- a/aosp/common/backblaze_keygen.sh
+++ b/aosp/common/backblaze_keygen.sh
@@ -44,11 +44,15 @@ if [ "${DCDEVSPACE:-0}" == "1" ]; then
     done
 
     # Generate APEX keys with passwords
+    cp ./development/tools/make_key "$CERT_DIR"/make_key
+    sed -i 's|2048|4096|g' "$CERT_DIR"/make_key
     for apex in com.android.adbd com.android.adservices com.android.adservices.api com.android.appsearch com.android.art com.android.bluetooth com.android.btservices com.android.cellbroadcast com.android.compos com.android.configinfrastructure com.android.connectivity.resources com.android.conscrypt com.android.devicelock com.android.extservices com.android.graphics.pdf com.android.hardware.biometrics.face.virtual com.android.hardware.biometrics.fingerprint.virtual com.android.hardware.boot com.android.hardware.cas com.android.hardware.wifi com.android.healthfitness com.android.hotspot2.osulogin com.android.i18n com.android.ipsec com.android.media com.android.media.swcodec com.android.mediaprovider com.android.nearby.halfsheet com.android.networkstack.tethering com.android.neuralnetworks com.android.ondevicepersonalization com.android.os.statsd com.android.permission com.android.resolv com.android.rkpd com.android.runtime com.android.safetycenter.resources com.android.scheduling com.android.sdkext com.android.support.apexer com.android.telephony com.android.telephonymodules com.android.tethering com.android.tzdata com.android.uwb com.android.uwb.resources com.android.virt com.android.vndk.current com.android.vndk.current.on_vendor com.android.wifi com.android.wifi.dialog com.android.wifi.resources com.google.pixel.camera.hal com.google.pixel.vibrator.hal com.qorvo.uwb; do
         apex_subject="/C=US/ST=California/L=Mountain View/O=Android/OU=Android/CN=$apex/emailAddress=android@android.com"
-        ./development/tools/make_key "$CERT_DIR/$apex" "$apex_subject" -password pass:"$PASSWORD"
+        "$CERT_DIR"/make_key "$CERT_DIR/$apex" "$apex_subject" -password pass:"$PASSWORD"
         openssl pkcs8 -in "$CERT_DIR/$apex.pk8" -inform DER -out "$CERT_DIR/$apex.pem" -passin pass:"$PASSWORD" -passout pass:"$PASSWORD"
     done
+    # Clean the Dir from makefile
+    rm "$CERT_DIR"/make_key
 
     # Installing B2 if not there
     if ! command -v b2 &> /dev/null; then


### PR DESCRIPTION
* APEX only accept SHA256_RSA4096 key, not SHA256_RSA2048. ref: https://wiki.lineageos.org/signing_builds

test: build without APEX errors.
