### PR TITLE
remove background argument from the shellinabox command

### DIFF
--- a/crave/devspace/shellinabox.conf
+++ b/crave/devspace/shellinabox.conf
@@ -1,7 +1,7 @@
 [program:shellinabox]
 priority=10
 directory=/
-command=sudo /usr/bin/shellinaboxd -q --background=/var/run/shellinaboxd.pid -c /var/lib/shellinabox -p 5898 -u shellinabox -g shellinabox --user-css "Black on White:+/etc/shellinabox/options-enabled/00+Black on White.css,White On Black:-/etc/shellinabox/options-enabled/00_White On Black.css;Color Terminal:+/etc/shellinabox/options-enabled/01+Color Terminal.css,Monochrome:-/etc/shellinabox/options-enabled/01_Monochrome.css" -s /:admin:admin:/crave-devspaces:bash -t --no-beep
+command=sudo /usr/bin/shellinaboxd -q -c /var/lib/shellinabox -p 5898 -u shellinabox -g shellinabox --user-css "Black on White:+/etc/shellinabox/options-enabled/00+Black on White.css,White On Black:-/etc/shellinabox/options-enabled/00_White On Black.css;Color Terminal:+/etc/shellinabox/options-enabled/01+Color Terminal.css,Monochrome:-/etc/shellinabox/options-enabled/01_Monochrome.css" -s /:admin:admin:/crave-devspaces:bash -t --no-beep
 user=admin
 environment=HOME="/home/admin",USER="admin"
 autostart=false


### PR DESCRIPTION
since it is being run inside supervisor, it'll take care of daemonizing it Inherently being run in background is causing the process to exit and misleading supervisor to think that its a spawn error.