### PR TITLE
baseimages: ubuntu(22.04): Add python2 package

### DIFF
--- a/baseimages/phase1/ubuntu/22.04/Dockerfile
+++ b/baseimages/phase1/ubuntu/22.04/Dockerfile
@@ -62,6 +62,7 @@ RUN set -x \
       ninja-build \
       openssh-server \
       psmisc \
+      python2 \
       # install rsync because it allows the updated rsync to work correctly
       rsync \
       subversion \


### PR DESCRIPTION
Older kernels like 4.14.xxx use scripts like DrvGen which uses python2 explicitly, without which the build fails.