### PR TITLE
resync: Update Failing repos awk filter with wildcard and sort unique

### DIFF
--- a/aosp/common/resync.sh
+++ b/aosp/common/resync.sh
@@ -34,7 +34,7 @@ main() {
             # Delete the repository
             rm -rf "$repo_path/$repo_name"
             rm -rf ".repo/project/$repo_path/$repo_name"/*.git
-        done <<< "$(cat /tmp/output.txt | awk '/Failing repos:/ {flag=1; next} /Try/ {flag=0} flag')"
+        done <<< "$(cat /tmp/output.txt | awk '/Failing repos.*:/ {flag=1; next} /Try/ {flag=0} flag' | sort -u)"
     fi
 
     # Check if there are any failing repositories due to uncommitted changes


### PR DESCRIPTION
The following projects failed and could not be synced:
 - prebuilts/clang-tools error: Unable to fully sync the tree
error: Checking out local projects failed.
Failing repos (checkout):
prebuilts/clang-tools
prebuilts/clang-tools
prebuilts/clang-tools
Try re-running with "-j1 --fail-fast" to exit at the first error.