### PR TITLE
Fix quoting for gh release commands in upload.sh

### DIFF
--- a/aosp/common/upload.sh
+++ b/aosp/common/upload.sh
@@ -63,6 +63,6 @@ if [ "${DCDEVSPACE}" == "1" ]; then
     crave push token.txt -d $(crave ssh -- pwd | grep -v Select | sed -s 's/\r//g')/
     crave ssh -- "export GH_UPLOAD_LIMIT="$GH_UPLOAD_LIMIT"; bash /opt/crave/github-actions/upload.sh "$RELEASETAG" "$DEVICE" "$REPONAME" "$RELEASETITLE""
 else
-    gh release create $RELEASETAG $EXTRAFILES --repo $REPONAME --title $RELEASETITLE --generate-notes
-    gh release upload $RELEASETAG --repo $REPONAME $ZIP_FILES $IMG_FILES
+    gh release create "$RELEASETAG" $EXTRAFILES --repo "$REPONAME" --title "$RELEASETITLE" --generate-notes
+    gh release upload "$RELEASETAG" --repo "$REPONAME" $ZIP_FILES $IMG_FILES
 fi


### PR DESCRIPTION
The gh release create command did not quote $RELEASETITLE, causing the command to fail when the release title contains spaces (e.g., "official flame"). This adds double quotes around $RELEASETITLE, $RELEASETAG, and $REPONAME in both the create and upload commands to properly handle titles with spaces and prevent word splitting.